### PR TITLE
Add support for using Jira sprints to schedule and set deadlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,25 @@ THINGS_TAGS=['jira', 'work']
 JIRA_TYPE_TAG=true
 ```
 
-### Status Mapping
+### Sprint Deadlines
+
+Set task deadlines based on the end dates of Jira sprints. Only active and future sprints are considered.
+
+```ini
+JIRA_SPRINT_DEADLINES=true
+```
+
+### Status Mapping / Scheduling
+
+Tickets can be scheduled using one of two scheduling modes: `status` or `sprint`.
+
+#### Status Mode
+
+In status mode, tickets are scheduled based soley on their Jira status. This is the default mode.
+
+```ini
+SCHEDULING_MODE=status
+```
 
 Configure how JIRA statuses map to Things scheduling:
 
@@ -134,9 +152,22 @@ ANYTIME_STATUS=['To Do', 'Open', 'New']
 COMPLETED_STATUS=['Done', 'Closed', 'Resolved']
 ```
 
-## Status Mapping Logic
+#### Sprint Mode
 
-The app maps JIRA ticket statuses to Things 3 scheduling areas:
+```ini
+SCHEDULING_MODE=sprint
+```
+
+In `sprint` mode, tickets are scheduled based on their sprint and status:
+
+- Tickets in an active sprint are scheduled to "Anytime"
+- Tickets in past/future sprints are scheduled to "Someday"
+- Any tickets with a status in `TODAY_STATUS` are scheduled to "Today"
+- Tickets with a status in `COMPLETED_STATUS` are marked as completed in Things
+
+## Status / Scheduling Logic
+
+The app maps JIRA ticket statuses or sprints to Things 3 scheduling areas:
 
 - **Today**: Urgent/active work (appears in Today view)
 - **Anytime**: Ready to work on (appears in Anytime list)

--- a/config.example
+++ b/config.example
@@ -2,7 +2,12 @@
 JIRA_BASE_URL=https://your-company.atlassian.net
 JIRA_API_TOKEN=your_jira_api_token_here
 JIRA_USER_EMAIL=your.email@company.com
+
+# JQL Query to select Jira issues for syncing
 JIRA_JQL_QUERY=assignee = currentUser() AND updated >= -14d
+
+# If using Sprints, you may want to modify the query to ensure all items in the current sprint are included:
+# JIRA_JQL_QUERY=assignee = currentUser() AND (updated >= -14d or Sprint IN openSprints())
 
 # Things 3 Configuration - Required for Things sync
 THINGS_AUTH_TOKEN=your_things_auth_token_here
@@ -15,15 +20,27 @@ THINGS_TAGS=["jira", "work"]
 # Make sure these tags exist in Things first!
 JIRA_TYPE_TAG=true
 
+# Set task deadlines based on the end date of active/future Jira sprints
+JIRA_SPRINT_DEADLINES=true
+
 # Status Mapping - Configure how JIRA statuses map to Things scheduling
+
 # Tickets with these statuses go to "Today" in Things
 TODAY_STATUS=["In Progress", "Active", "Doing"]
 
-# Tickets with these statuses go to "Anytime" in Things (default for unlisted statuses)
+# Tickets with these statuses are marked as completed in Things
+COMPLETED_STATUS=["Done", "Closed", "Resolved", "Completed"]
+
+# Set the scheduling mode for Things tasks
+#
+# When set to "status", the lists below determine how tasks are scheduled
+# between "Anytime" and "Someday". When set to "sprint", tasks in the active
+# sprint are set to "Anytime" and all other tasks are set to "Someday".
+SCHEDULING_MODE=status
+
+# In "status" mode, tickets with these statuses go to "Anytime" in Things
+# (default for unlisted statuses)
 ANYTIME_STATUS=["To Do", "Open", "Ready", "Dev Ready"]
 
-# Tickets with these statuses go to "Someday" in Things  
+# In "status" mode, tickets with these statuses go to "Someday" in Things
 SOMEDAY_STATUS=["Backlog", "Future", "Product Backlog", "Icebox"]
-
-# Tickets with these statuses are marked as completed in Things
-COMPLETED_STATUS=["Done", "Closed", "Resolved", "Completed"] 

--- a/database.py
+++ b/database.py
@@ -1,6 +1,7 @@
 import sqlite3
 import logging
 from contextlib import contextmanager
+from datetime import datetime
 from typing import Dict, List, Optional
 from dataclasses import dataclass
 
@@ -13,12 +14,15 @@ class JiraTicket:
     has_subtasks: bool
     status: str
     issue_type: str = None
+    sprint_name: Optional[str] = None
+    sprint_status: Optional[str] = None
+    sprint_end_time: Optional[str] = None
     things_id: str = None
     last_updated: str = None
 
 class DatabaseManager:
     """Manages SQLite database operations for JIRA tickets."""
-    
+
     def __init__(self, db_path: str, jira_base_url: str):
         self.db_path = db_path
         self.jira_base_url = jira_base_url.rstrip('/')  # Remove trailing slash if present
@@ -49,12 +53,27 @@ class DatabaseManager:
                     has_subtasks BOOLEAN NOT NULL,
                     status TEXT,
                     issue_type TEXT,
+                    sprint_name TEXT,
+                    sprint_status TEXT,
+                    sprint_end_time TIMESTAMP,
                     things_id TEXT,
                     added_to_db TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     synced_to_things TEXT DEFAULT 'not synced' CHECK(synced_to_things IN ('synced', 'not synced', 'unknown')),
                     last_updated TIMESTAMP
                 )
             ''')
+
+            # We don't have a full schema migration system, so this just attempts to add
+            # any new columns from after the 1.0 release and skips if they already exist.
+            for field in ['sprint_name TEXT', 'sprint_status TEXT', 'sprint_end_time TEXT']:
+                try:
+                    cursor.execute(f"ALTER TABLE jira_tickets ADD COLUMN {field};")
+                except sqlite3.OperationalError as e:
+                    if "duplicate column name" not in str(e):
+                        raise
+
+                    logging.debug(f"Column '{field}' already exists, skipping addition")
+
             conn.commit()
             logging.info("Database initialization complete")
 
@@ -66,7 +85,7 @@ class DatabaseManager:
         with self.get_connection() as conn:
             cursor = conn.cursor()
             cursor.execute('''
-                SELECT summary, description, status, issue_type, things_id, synced_to_things 
+                SELECT summary, description, status, issue_type, sprint_name, sprint_status, sprint_end_time, things_id, synced_to_things
                 FROM jira_tickets WHERE ticket_id = ?
             ''', (ticket.ticket_id,))
             row = cursor.fetchone()
@@ -74,16 +93,21 @@ class DatabaseManager:
             
             if row:
                 # Ticket exists - check for content changes
-                existing_summary, existing_description, existing_status, existing_issue_type, existing_things_id, existing_synced = row
+                existing_summary, existing_description, existing_status, existing_issue_type, existing_sprint_name, existing_sprint_status, existing_sprint_end_time, existing_things_id, existing_synced = row
                 if not things_id:
                     things_id = existing_things_id
                 
                 # Compare all relevant fields for changes
-                has_changes = (existing_summary != ticket.summary or 
-                              existing_description != ticket.description or 
-                              existing_status != ticket.status or 
-                              existing_issue_type != ticket.issue_type)
-                
+                has_changes = (
+                    existing_summary != ticket.summary or
+                    existing_description != ticket.description or
+                    existing_status != ticket.status or
+                    existing_issue_type != ticket.issue_type or
+                    existing_sprint_name != ticket.sprint_name or
+                    existing_sprint_status != ticket.sprint_status or
+                    existing_sprint_end_time != ticket.sprint_end_time
+                )
+
                 if not has_changes:
                     # No changes detected - exit early without DB writes
                     logging.debug(f"No changes detected for ticket {ticket.ticket_id}, preserving sync status")
@@ -92,23 +116,27 @@ class DatabaseManager:
                     # Changes detected - update ticket and mark as unsynced
                     logging.info(f"Changes detected for ticket {ticket.ticket_id}, marking as not synced")
                     cursor.execute('''
-                        UPDATE jira_tickets 
-                        SET summary = ?, description = ?, has_subtasks = ?, status = ?, 
-                            issue_type = ?, things_id = ?, synced_to_things = ?, last_updated = CURRENT_TIMESTAMP
+                        UPDATE jira_tickets
+                        SET summary = ?, description = ?, has_subtasks = ?, status = ?,
+                            issue_type = ?, sprint_name = ?, sprint_status = ?, sprint_end_time = ?,
+                            things_id = ?, synced_to_things = ?, last_updated = CURRENT_TIMESTAMP
                         WHERE ticket_id = ?
-                    ''', (ticket.summary, ticket.description, ticket.has_subtasks, ticket.status, 
-                          ticket.issue_type, things_id, 'not synced', ticket.ticket_id))
+                    ''', (ticket.summary, ticket.description, ticket.has_subtasks, ticket.status,
+                          ticket.issue_type, ticket.sprint_name, ticket.sprint_status, ticket.sprint_end_time,
+                          things_id, 'not synced', ticket.ticket_id))
             else:
                 # New ticket - insert with current timestamps
                 logging.debug(f"Inserting new ticket {ticket.ticket_id}")
                 cursor.execute('''
-                    INSERT INTO jira_tickets 
-                    (ticket_id, summary, description, has_subtasks, status, issue_type, 
+                    INSERT INTO jira_tickets
+                    (ticket_id, summary, description, has_subtasks, status, issue_type,
+                     sprint_name, sprint_status, sprint_end_time,
                      things_id, synced_to_things, added_to_db, last_updated)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
-                ''', (ticket.ticket_id, ticket.summary, ticket.description, ticket.has_subtasks, 
-                      ticket.status, ticket.issue_type, things_id, 'not synced'))
-            
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                ''', (ticket.ticket_id, ticket.summary, ticket.description, ticket.has_subtasks,
+                      ticket.status, ticket.issue_type, ticket.sprint_name, ticket.sprint_status,
+                      ticket.sprint_end_time, things_id, 'not synced'))
+
             conn.commit()
 
     def get_all_tickets(self) -> List[JiraTicket]:
@@ -116,7 +144,7 @@ class DatabaseManager:
         with self.get_connection() as conn:
             cursor = conn.cursor()
             logging.debug("Retrieving all tickets from database")
-            cursor.execute('SELECT ticket_id, summary, description, has_subtasks, status, issue_type, things_id, last_updated FROM jira_tickets')
+            cursor.execute('SELECT ticket_id, summary, description, has_subtasks, status, issue_type, sprint_name, sprint_status, sprint_end_time, things_id, last_updated FROM jira_tickets')
             return [JiraTicket(*row) for row in cursor.fetchall()]
 
     def get_unsynced_tickets(self) -> List[JiraTicket]:
@@ -124,9 +152,10 @@ class DatabaseManager:
         with self.get_connection() as conn:
             cursor = conn.cursor()
             cursor.execute('''
-                SELECT ticket_id, summary, description, has_subtasks, status, 
-                       issue_type, things_id, last_updated 
-                FROM jira_tickets 
+                SELECT ticket_id, summary, description, has_subtasks, status,
+                       issue_type, sprint_name, sprint_status, sprint_end_time,
+                       things_id, last_updated
+                FROM jira_tickets
                 WHERE synced_to_things = 'not synced'
             ''')
             return [JiraTicket(*row) for row in cursor.fetchall()]
@@ -135,8 +164,8 @@ class DatabaseManager:
         """Retrieve a specific ticket by its ID. Returns None if not found."""
         with self.get_connection() as conn:
             cursor = conn.cursor()
-            cursor.execute('SELECT ticket_id, summary, description, has_subtasks, status, issue_type, things_id, last_updated FROM jira_tickets WHERE ticket_id = ?', (ticket_id,))
+            cursor.execute('SELECT ticket_id, summary, description, has_subtasks, status, issue_type, sprint_name, sprint_status, sprint_end_time, things_id, last_updated FROM jira_tickets WHERE ticket_id = ?', (ticket_id,))
             row = cursor.fetchone()
             if row:
                 return JiraTicket(*row)
-            return None 
+            return None


### PR DESCRIPTION
This adds basic support for Jira sprints:

- The database is updated to add sprint_name, sprint_status, and sprint_end_date
- If JIRA_SPRINT_DEADLINES=true is set in the config, the end date of a ticket's sprint will be used to set its deadline in Things
- If SCHEDULING_MODE=sprint is set in the config, tasks in the active sprint will be set to `Anytime` and those in past/future/no sprint will be set to `Someday`
