### PR TITLE
Updated Jira package to resolve deprecated API usage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ jaraco.classes==3.4.0
 jaraco.context==6.0.1
 jaraco.functools==4.1.0
 jedi==0.19.2
-jira==3.8.0
+jira==3.10.5
 keyring==25.6.0
 matplotlib-inline==0.1.7
 more-itertools==10.7.0


### PR DESCRIPTION
I started to get errors today from Atlassian:

>ERROR - Error fetching issues from JIRA: JiraError HTTP 410 url: https://my-firm.atlassian.net/rest/api/2/search?jql=my+query&startAt=0&validateQuery=True&fields=summary&fields=subtasks&fields=status&fields=issuetype&maxResults=100
>	text: The requested API has been removed. Please use the newer, enhanced search-based API instead. Deprecation details are available at https://developer.atlassian.com/changelog/#CHANGE-2046.

Upgrading the JIRA package resolved the problem.